### PR TITLE
Expand path name in source directory

### DIFF
--- a/sphinx-frontend.el
+++ b/sphinx-frontend.el
@@ -48,7 +48,7 @@ Returns current document's tree root directory."
   (let ((current-dir (sphinx-get-root-document-dir)))
     (concat sphinx-build-command " " output-format " "
             ;; sourcedir
-            (shell-quote-argument (file-name-as-directory current-dir)) " "
+            (shell-quote-argument (file-name-as-directory (expand-file-name current-dir))) " "
             ;; outdir
             (shell-quote-argument (file-name-as-directory
                                    (expand-file-name output-dir current-dir))))))


### PR DESCRIPTION
This means we don't end up with a source directory that starts with a ~,
which is then escaped -- resulting in this module not being able to find
the source directory.

This fixes #5
